### PR TITLE
Change prompt2 to prompt-cont

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,2 +1,2 @@
 :set prompt ">>> "
-:set prompt2 "... "
+:set prompt-cont "... "


### PR DESCRIPTION
The interface has changed since GHC 8.2.1, and `prompt2` is now `promp-cont`
The resolver version is [LTS-17.0](https://www.stackage.org/lts-17.0), which resolves to GHC 8.10.3

https://stackoverflow.com/a/47694134